### PR TITLE
Switch to relative imports throughout project

### DIFF
--- a/test_few.py
+++ b/test_few.py
@@ -8,15 +8,15 @@ from torch import nn
 from torch.nn import functional as F
 from tqdm import tqdm
 from scipy.ndimage import gaussian_filter
-from dataset.medical_few import MedDataset
-from CLIP.clip import create_model
-from CLIP.tokenizer import tokenize
-from CLIP.adapter import CLIP_Inplanted
+from .dataset.medical_few import MedDataset
+from .CLIP.clip import create_model
+from .CLIP.tokenizer import tokenize
+from .CLIP.adapter import CLIP_Inplanted
 from PIL import Image
 from sklearn.metrics import roc_auc_score, precision_recall_curve, pairwise
-from loss import FocalLoss, BinaryDiceLoss
-from utils import augment, cos_sim, encode_text_with_prompt_ensemble
-from prompt import REAL_NAME
+from .loss import FocalLoss, BinaryDiceLoss
+from .utils import augment, cos_sim, encode_text_with_prompt_ensemble
+from .prompt import REAL_NAME
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 import warnings

--- a/test_zero.py
+++ b/test_zero.py
@@ -9,15 +9,15 @@ from torch.nn import functional as F
 from tqdm import tqdm
 from sklearn.metrics import roc_auc_score
 from scipy.ndimage import gaussian_filter
-from dataset.medical_zero import MedTestDataset, MedTrainDataset
-from CLIP.clip import create_model
-from CLIP.tokenizer import tokenize
-from CLIP.adapter import CLIP_Inplanted
+from .dataset.medical_zero import MedTestDataset, MedTrainDataset
+from .CLIP.clip import create_model
+from .CLIP.tokenizer import tokenize
+from .CLIP.adapter import CLIP_Inplanted
 from PIL import Image
 from sklearn.metrics import precision_recall_curve
-from loss import FocalLoss, BinaryDiceLoss
-from utils import augment, encode_text_with_prompt_ensemble
-from prompt import REAL_NAME
+from .loss import FocalLoss, BinaryDiceLoss
+from .utils import augment, encode_text_with_prompt_ensemble
+from .prompt import REAL_NAME
 
 import warnings
 warnings.filterwarnings("ignore")

--- a/train_few.py
+++ b/train_few.py
@@ -8,15 +8,15 @@ from torch import nn
 from torch.nn import functional as F
 from tqdm import tqdm
 from scipy.ndimage import gaussian_filter
-from dataset.medical_few import MedDataset
-from CLIP.clip import create_model
-from CLIP.tokenizer import tokenize
-from CLIP.adapter import CLIP_Inplanted
+from .dataset.medical_few import MedDataset
+from .CLIP.clip import create_model
+from .CLIP.tokenizer import tokenize
+from .CLIP.adapter import CLIP_Inplanted
 from PIL import Image
 from sklearn.metrics import roc_auc_score, precision_recall_curve, pairwise
-from loss import FocalLoss, BinaryDiceLoss
-from utils import augment, cos_sim, encode_text_with_prompt_ensemble
-from prompt import REAL_NAME
+from .loss import FocalLoss, BinaryDiceLoss
+from .utils import augment, cos_sim, encode_text_with_prompt_ensemble
+from .prompt import REAL_NAME
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 import warnings

--- a/train_zero.py
+++ b/train_zero.py
@@ -9,15 +9,15 @@ from torch.nn import functional as F
 from tqdm import tqdm
 from sklearn.metrics import roc_auc_score
 from scipy.ndimage import gaussian_filter
-from dataset.medical_zero import MedTestDataset, MedTrainDataset
-from CLIP.clip import create_model
-from CLIP.tokenizer import tokenize
-from CLIP.adapter import CLIP_Inplanted
+from .dataset.medical_zero import MedTestDataset, MedTrainDataset
+from .CLIP.clip import create_model
+from .CLIP.tokenizer import tokenize
+from .CLIP.adapter import CLIP_Inplanted
 from PIL import Image
 from sklearn.metrics import precision_recall_curve
-from loss import FocalLoss, BinaryDiceLoss
-from utils import augment, encode_text_with_prompt_ensemble
-from prompt import REAL_NAME
+from .loss import FocalLoss, BinaryDiceLoss
+from .utils import augment, encode_text_with_prompt_ensemble
+from .prompt import REAL_NAME
 
 import warnings
 warnings.filterwarnings("ignore")

--- a/utils.py
+++ b/utils.py
@@ -3,7 +3,7 @@ import torch
 import torch.nn.functional as F
 import kornia as K
 from PIL import Image
-from CLIP.tokenizer import tokenize
+from .CLIP.tokenizer import tokenize
 
 
 def encode_text_with_prompt_ensemble(model, obj, device):


### PR DESCRIPTION
## Summary
- Replace absolute imports with explicit relative imports in training, testing, and utility scripts

## Testing
- `python -m py_compile train_zero.py test_zero.py test_few.py train_few.py utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68be8b694628832498621697651fc00e